### PR TITLE
Externalize previous position

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,23 +24,29 @@ npm install --save leaflet react-leaflet
 
 Inherits props from `leaflet-drift-marker` and still supports all existing props from [react-leaflet marker](https://react-leaflet.js.org/docs/api-components/#marker)
 
-| Props            | Type               | Default    | Description                                                                                                                 |
-| ---------------- | ------------------ | ---------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `position`       | `LatLngExpression` |            | The current coordinates                                                                                                     |
-| `rotationOrigin` | `String`           | `'center'` | The rotation center, as a [`transform-origin`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-origin) CSS rule. |
-| `duration`       | `number`           |            | Required, duration in milliseconds marker will take to destination point                                                    |
-| `keepAtCenter`   | `boolean`          | `false`    | Makes map view follow marker                                                                                                |
+| Props              | Type               | Default    | Description                                                                                                                 |
+| ------------------ | ------------------ | ---------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `position`         | `LatLngExpression` |            | The current coordinates. This is mandatory.|
+| `previousPosition` | `LatLngExpression` |            | The previous point coordinates, **Allows the marker to automatically computes its rotation angle.** This is mandatory.|
+| `rotationOrigin`   | `String`           | `'center'` | The rotation center, as a [`transform-origin`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-origin) CSS rule. |
+| `duration`         | `number`           |            | Required, duration in milliseconds marker will take to destination point                                                    |
+| `keepAtCenter`     | `boolean`          | `false`    | Makes map view follow marker                                                                                                |
 
 #### Example
 
-```jsx
+```js
 import LeafletTrackingMarker from 'react-leaflet-tracking-marker'
 
-<LeafletTrackingMarker
-  icon={icon}
-  position={[latitude, longitude]}
-  duration={1000}
-/>
+function AirplaneMarker({ data }) {
+  const { latitude, longitude } = data
+  const [prevPos, setPrevPos] = useState([latitude, longitude])
+
+  useEffect(() => {
+    if (prevPos[1] !== longitude && prevPos[0] !== latitude) setPrevPos([latitude, longitude])
+  }, [latitude, longitude, prevPos])
+
+  return <LeafletTrackingMarker icon={icon} position={[latitude, longitude]} previousPosition={prevPos} duration={1000} />
+}
 ```
 
 # License

--- a/src/LeafletTrackingMarker.js
+++ b/src/LeafletTrackingMarker.js
@@ -1,5 +1,4 @@
-import { createElementHook, createPathHook } from '@react-leaflet/core'
-import { useEffect, useState } from 'react'
+import { createLayerComponent } from '@react-leaflet/core'
 import { BaseMarker } from './BaseMarker'
 
 let previousBearingAngle = 0
@@ -14,8 +13,7 @@ const computeBearing = (previousPosition, nexPosition) => {
 const createMarker = ({ position, previousPosition, ...options }, ctx) => {
   const bearingAngle = computeBearing(previousPosition, position)
   if (bearingAngle !== previousBearingAngle) previousBearingAngle = bearingAngle
-
-  const instance = new BaseMarker(position, { ...options, bearingAngle: previousBearingAngle })
+  const instance = new BaseMarker(position, { ...options, bearingAngle })
   return { instance, context: { ...ctx, overlayContainer: instance } }
 }
 
@@ -53,16 +51,4 @@ const updateMarker = (marker, props, prevProps) => {
   }
 }
 
-const useLeafletTrackingMarker = createPathHook(createElementHook(createMarker, updateMarker))
-
-export const LeafletTrackingMarker = props => {
-  const { position } = props
-  const [prevPos, setPrevPos] = useState(position)
-
-  useEffect(() => {
-    if (prevPos[0] !== position[0] && prevPos[1] !== position[1]) setPrevPos(position)
-  }, [position, prevPos])
-
-  useLeafletTrackingMarker({ ...props, previousPosition: prevPos })
-  return null
-}
+export const LeafletTrackingMarker = createLayerComponent(createMarker, updateMarker)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,6 +11,10 @@ export class LeafletTrackingMarker extends Marker {
 
 interface TrackingMarkerOptions extends MarkerOptions {
   /*
+   * Previous position coordinates used to compute the bearing angle in degrees, clockwise. Defaults to 'center'
+   */
+  previousPosition: LatLngExpression
+  /*
    * Rotation angle, in degrees, clockwise. Defaults to 'center'
    */
   rotationOrigin?: string


### PR DESCRIPTION
Previous position should not be computed inside the marker, there are some issues with React Leaflet v3, children are not passed to base Marker class when using custom React Leaflet hooks.