### PR TITLE
Fix marker rotation

### DIFF
--- a/src/LeafletTrackingMarker.js
+++ b/src/LeafletTrackingMarker.js
@@ -12,7 +12,6 @@ const computeBearing = (previousPosition, nexPosition) => {
 
 const createMarker = ({ position, previousPosition, ...options }, ctx) => {
   const bearingAngle = computeBearing(previousPosition, position)
-  if (bearingAngle !== previousBearingAngle) previousBearingAngle = bearingAngle
   const instance = new BaseMarker(position, { ...options, bearingAngle })
   return { instance, context: { ...ctx, overlayContainer: instance } }
 }


### PR DESCRIPTION
Condition inside the createMarker function  `if (bearingAngle !== previousBearingAngle) previousBearingAngle = bearingAngle `prevents marker from rotating because it keps the values of `previousBearingAngle `and `bearingAngle `always the same.

Fixes #2