### PR TITLE
updated marker props type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,8 @@
 import { type ForwardRefExoticComponent, type RefAttributes } from 'react'
-import { type LatLngExpression, Marker, type MarkerOptions } from 'leaflet'
+import { type LatLngExpression, Marker } from 'leaflet'
+import { type MarkerProps } from 'react-leaflet';
 
-interface TrackingMarkerOptions extends MarkerOptions {
+interface TrackingMarkerOptions extends MarkerProps {
   /*
    * Previous position coordinates used to compute the bearing angle in degrees, clockwise. Defaults to 'center'
    */


### PR DESCRIPTION
For issue #8 
With previous version of types I can't use children properties on the wonderful component. 
Current changes extend react-leaflet marker properties to supporting **children** properties to using popup with the component. 